### PR TITLE
remove readlines()

### DIFF
--- a/label_maker/stream_filter.py
+++ b/label_maker/stream_filter.py
@@ -5,7 +5,7 @@ from shapely.geometry import shape, box
 
 bbox = box(*json.loads(sys.argv[1]))
 
-for line in sys.stdin.readlines():
+for line in sys.stdin:
     geo = json.loads(line)
     geom = shape(geo['geometry'])
     geo.pop('tippecanoe')


### PR DESCRIPTION
stdin.readlines() is causing the entire output of tippecanoe-decode to be buffered instead of streamed. For very large mbtiles (like the United States), this generates unreasonably high memory usage.