### PR TITLE
preview: make tiles subdir and provide default for imagery_offset arg

### DIFF
--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -66,7 +66,7 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
 
     # download tiles
     tiles = class_tiles + background_tiles
-    print('Downloading {} tiles to {}'.format(len(tiles), op.join(dest_folder, 'tiles')))
+    print('Downloading {} tiles to {}'.format(len(tiles), tiles_dir))
 
     # get image acquisition function based on imagery string
     image_function = download_tile_tms
@@ -74,4 +74,4 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
         image_function = get_tile_tif
 
     for tile in tiles:
-        image_function(tile, imagery, dest_folder, imagery_offset)
+        image_function(tile, imagery, tiles_dir, imagery_offset)

--- a/label_maker/preview.py
+++ b/label_maker/preview.py
@@ -9,7 +9,7 @@ from PIL import Image, ImageDraw
 
 from label_maker.utils import class_match, download_tile_tms, get_tile_tif, is_tif
 
-def preview(dest_folder, number, classes, imagery, ml_type, imagery_offset, **kwargs):
+def preview(dest_folder, number, classes, imagery, ml_type, imagery_offset=False, **kwargs):
     """Produce imagery examples for specified classes
 
     Parameters
@@ -55,8 +55,12 @@ def preview(dest_folder, number, classes, imagery, ml_type, imagery_offset, **kw
     for i, cl in enumerate(classes):
         # create class directory
         class_dir = op.join(dest_folder, 'examples', cl.get('name'))
-        if not op.isdir(class_dir):
-            makedirs(class_dir)
+
+        # the download process downloads into a tiles subdirectory so create that here
+        class_tile_dir = op.join(class_dir, 'tiles')
+
+        if not op.isdir(class_tile_dir):
+            makedirs(class_tile_dir)
 
         class_tiles = (t for t in tiles.files
                        if class_match(ml_type, tiles[t], i + 1))

--- a/label_maker/preview.py
+++ b/label_maker/preview.py
@@ -56,11 +56,8 @@ def preview(dest_folder, number, classes, imagery, ml_type, imagery_offset=False
         # create class directory
         class_dir = op.join(dest_folder, 'examples', cl.get('name'))
 
-        # the download process downloads into a tiles subdirectory so create that here
-        class_tile_dir = op.join(class_dir, 'tiles')
-
-        if not op.isdir(class_tile_dir):
-            makedirs(class_tile_dir)
+        if not op.isdir(class_dir):
+            makedirs(class_dir)
 
         class_tiles = (t for t in tiles.files
                        if class_match(ml_type, tiles[t], i + 1))

--- a/label_maker/utils.py
+++ b/label_maker/utils.py
@@ -24,16 +24,16 @@ def class_match(ml_type, label, i):
         return np.count_nonzero(label == i)
     return None
 
-def download_tile_tms(tile, imagery, dest_folder, *args):
+def download_tile_tms(tile, imagery, folder, *args):
     """Download a satellite image tile from a tms endpoint"""
     o = urlparse(imagery)
     _, image_format = op.splitext(o.path)
     r = requests.get(url(tile.split('-'), imagery))
-    tile_img = op.join(dest_folder, 'tiles', '{}{}'.format(tile, image_format))
+    tile_img = op.join(folder, '{}{}'.format(tile, image_format))
     open(tile_img, 'wb').write(r.content)
     return tile_img
 
-def get_tile_tif(tile, imagery, dest_folder, imagery_offset):
+def get_tile_tif(tile, imagery, folder, imagery_offset):
     """
     Read a GeoTIFF with a window corresponding to a TMS tile
 
@@ -80,7 +80,7 @@ def get_tile_tif(tile, imagery, dest_folder, imagery_offset):
             src.read(k, window=window, out=data[k - 1], boundless=True)
 
         # save
-        tile_img = op.join(dest_folder, 'tiles', '{}{}'.format(tile, '.jpg'))
+        tile_img = op.join(folder, '{}{}'.format(tile, '.jpg'))
         img = Image.fromarray(np.moveaxis(data, 0, -1), mode='RGB')
         img.save(tile_img)
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -52,7 +52,7 @@ class TestUtils(unittest.TestCase):
         if not op.isdir(tiles_dir):
             makedirs(tiles_dir)
 
-        get_tile_tif(tile, 'test/fixtures/drone.tif', dest_folder, None)
+        get_tile_tif(tile, 'test/fixtures/drone.tif', tiles_dir, None)
         test_tile = Image.open('test/tiles/{}.jpg'.format(tile))
         fixture_tile = Image.open('test/fixtures/{}.jpg'.format(tile))
         self.assertEqual(test_tile, fixture_tile)
@@ -66,7 +66,7 @@ class TestUtils(unittest.TestCase):
         if not op.isdir(tiles_dir):
             makedirs(tiles_dir)
 
-        get_tile_tif(tile, 'test/fixtures/drone.tif', dest_folder, [128, 64])
+        get_tile_tif(tile, 'test/fixtures/drone.tif', tiles_dir, [128, 64])
         test_tile = Image.open('test/tiles/{}.jpg'.format(tile))
         fixture_tile = Image.open('test/fixtures/{}_offset.jpg'.format(tile))
         self.assertEqual(test_tile, fixture_tile)
@@ -80,7 +80,7 @@ class TestUtils(unittest.TestCase):
         if not op.isdir(tiles_dir):
             makedirs(tiles_dir)
 
-        get_tile_tif(tile, 'test/fixtures/drone.vrt', dest_folder, None)
+        get_tile_tif(tile, 'test/fixtures/drone.vrt', tiles_dir, None)
         test_tile = Image.open('test/tiles/{}.jpg'.format(tile))
         fixture_tile = Image.open('test/fixtures/{}.jpg'.format(tile))
         self.assertEqual(test_tile, fixture_tile)


### PR DESCRIPTION
Two fixes to make `preview` cli command run successfully:
1. provide default value of `False` for imagery_offset
1. create `tiles` subdir in example directories for download functions to populate with tiles

Closes #79 