### PR TITLE
add label-maker binder example

### DIFF
--- a/examples/label-maker-binder.md
+++ b/examples/label-maker-binder.md
@@ -1,0 +1,12 @@
+# Using label-maker in an interactive notebook on the cloud
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/giswqs/label-maker-binder/master)
+
+## Usage
+
+* Launch [Binder](https://mybinder.org/v2/gh/giswqs/label-maker-binder/master) 
+* A Jupyter Notebook will open in your browser
+* Open **config.json** and replace **ACCESS_TOKEN** with your [mapbox access token](https://www.mapbox.com/account/access-tokens). You can also change the content of **config.json** (e.g., *country, bounding_box*) if needed.
+* Save changes to **config.json** (Menu - File - Save)
+* Open **label-maker-binder.ipynb** and start running cells 
+


### PR DESCRIPTION
I used label-maker in Manjaro Linux before, and it worked fine. The recent system updates of Manjaro Linux broke label-maker, resulting in [Error: Segmentation fault (core dumped)](https://github.com/developmentseed/label-maker/issues/116). I could not found a solution to resolve this issue. 

As a workaround, I deployed label-maker to [binder](https://mybinder.org/). Now anyone with an Internet browser can run label-maker without having to install it on their local computers. Here is the repo: [label-maker-binder](https://github.com/giswqs/label-maker-binder)    