### PR TITLE
Add option to split data into train/test/validate sets 

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -49,5 +49,13 @@ Here is the full list of configuration parameters you can specify in a ``config.
  	``'segmentation'``
  		Output is an array of shape ``(256, 256)`` with values matching the class index label at that position. The classes are applied sequentially according to ``config.json`` so latter classes will be written over earlier class labels if there is overlap.
 
+**split_vals:** list
+    Default: `[0.8, 0.2]`
+    Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
+
+**split_names**: list
+    Default: `['train', 'test']`
+    List of names for each subset of the data.
+
 **imagery_offset**:  list of ints
 	An optional list of integers representing the number of pixels to offset imagery. For example ``[15, -5]`` will move the images 15 pixels right and 5 pixels up relative to the requested tile bounds.

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -49,7 +49,10 @@ Here is the full list of configuration parameters you can specify in a ``config.
  	``'segmentation'``
  		Output is an array of shape ``(256, 256)`` with values matching the class index label at that position. The classes are applied sequentially according to ``config.json`` so latter classes will be written over earlier class labels if there is overlap.
 
-**split_vals:** list
+**seed**: int
+    Random generator seed. Optional, use to make results reproducible.
+
+**split_vals**: list
     Default: `[0.8, 0.2]`
     Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
 

--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -54,11 +54,11 @@ Here is the full list of configuration parameters you can specify in a ``config.
 
 **split_vals**: list
     Default: `[0.8, 0.2]`
-    Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
+    Percentage of data to put in each category listed in split_names. Must be a list of floats that sum to one and match the length of `split-names`. For train, validate, and test data, a list like `[0.7, 0.2, 0.1]` is suggested.
 
 **split_names**: list
     Default: `['train', 'test']`
-    List of names for each subset of the data.
+    List of names for each subset of the data. Length of list must match length of `split_vals`.
 
 **imagery_offset**:  list of ints
 	An optional list of integers representing the number of pixels to offset imagery. For example ``[15, -5]`` will move the images 15 pixels right and 5 pixels up relative to the requested tile bounds.

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -107,7 +107,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
         x_vals_split_lst = x_vals_split_lst[:-1]
 
     y_vals_split_lst = np.split(y_vals,
-                                [int(split_vals[0] * len(x_vals)), int((split_vals[0] + split_vals[1]) * len(x_vals))])
+                                [int(split_vals[0] * len(y_vals)), int((split_vals[0] + split_vals[1]) * len(y_vals))])
 
     if len(y_vals_split_lst[-1]) == 0:
         y_vals_split_lst = y_vals_split_lst[:-1]

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -35,7 +35,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
         Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
 
     split_names: lst
-        List of names for each subset of the data.
+        List of names for each subset of the data, either ['train', 'test'] or ['train', 'test', 'val']
 
     **kwargs: dict
         Other properties from CLI config passed as keywords to other utility functions
@@ -44,6 +44,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     if seed:
         np.random.seed(seed)
 
+    assert len(split_names) == 2 or len(split_names) == 3.
     assert len(split_names) == len(split_vals), "split_names and split_vals must be the same length."
     assert sum(split_vals) == 1, "split_vals must sum to one."
 

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -30,13 +30,10 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
         Defines the type of machine learning. One of "classification", "object-detection", or "segmentation"
     seed: int
         Random generator seed. Optional, use to make results reproducible.
-
-    split_vals: lst
+    split_vals: list
         Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
-
-    split_names: lst
+    split_names: list
         List of names for each subset of the data, either ['train', 'test'] or ['train', 'test', 'val']
-
     **kwargs: dict
         Other properties from CLI config passed as keywords to other utility functions
     """

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -99,16 +99,14 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
 
     # Convert lists to numpy arrays
     x_vals = np.array(x_vals, dtype=np.uint8)
-    print(x_vals.shape)
     y_vals = np.array(y_vals, dtype=np.uint8)
-    print(y_vals).shape
 
     # Get number of data samples per split from the float proportions
     split_n_samps = np.rint([len(x_vals) * val for val in split_vals])
-    print(split_n_samps)
+    #print(split_n_samps)
 
     if np.any(split_n_samps == 0):
-        raise ValueError
+        raise ValueError('split must not generate zero samples per partition, change ratio of values in config file.')
 
     # Convert into a cumulative sum to get indices
     split_inds = np.cumsum(split_n_samps).astype(np.integer)

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -103,7 +103,6 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
 
     # Get number of data samples per split from the float proportions
     split_n_samps = np.rint([len(x_vals) * val for val in split_vals])
-    #print(split_n_samps)
 
     if np.any(split_n_samps == 0):
         raise ValueError('split must not generate zero samples per partition, change ratio of values in config file.')

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -102,7 +102,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     y_vals = np.array(y_vals, dtype=np.uint8)
 
     # Get number of data samples per split from the float proportions
-    split_n_samps = np.rint([len(x_vals) * val for val in split_vals])
+    split_n_samps = [len(x_vals) * val for val in split_vals]
 
     if np.any(split_n_samps == 0):
         raise ValueError('split must not generate zero samples per partition, change ratio of values in config file.')

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -124,7 +124,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     if len(split_vals) == 3:
         np.savez(op.join(dest_folder, 'data.npz'),
                  x_train=x_vals_split_lst[0],
-                 y_train=y_vals_split_lst[1],
+                 y_train=y_vals_split_lst[0],
                  x_test=x_vals_split_lst[1],
                  y_test=y_vals_split_lst[1],
                  x_val=x_vals_split_lst[2],

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -9,7 +9,8 @@ from PIL import Image
 from label_maker.utils import is_tif
 
 
-def package_directory(dest_folder, classes, imagery, ml_type, seed=False, train_size=0.8, **kwargs):
+def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_names=['train', 'test'],
+                      split_vals=[0.8, .2], **kwargs):
     """Generate an .npz file containing arrays for training machine learning algorithms
 
     Parameters
@@ -37,6 +38,12 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, train_
     # if a seed is given, use it
     if seed:
         np.random.seed(seed)
+
+    assert len(split_names) == len(split_vals), "split_names and split_vals must be the same length." 
+    assert sum(split_vals) == 1, "split_vals must sum to one."
+
+
+
 
     # open labels file, create tile array
     labels_file = op.join(dest_folder, 'labels.npz')

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -31,9 +31,12 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     seed: int
         Random generator seed. Optional, use to make results reproducible.
     split_vals: list
-        Percentage of data to put in each catagory listed in split_names. Must be floats and must sum to one.
+        Default: [0.8, 0.2]
+        Percentage of data to put in each catagory listed in split_names.
+        Must be floats and must sum to one.
     split_names: list
-        List of names for each subset of the data, either ['train', 'test'] or ['train', 'test', 'val']
+        Default: ['train', 'test'] 
+        List of names for each subset of the data.
     **kwargs: dict
         Other properties from CLI config passed as keywords to other utility functions
     """
@@ -41,7 +44,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     if seed:
         np.random.seed(seed)
 
-    assert len(split_names) == 2 or len(split_names) == 3.
+    #assert len(split_names) == 2 or len(split_names) == 3.
     assert len(split_names) == len(split_vals), "split_names and split_vals must be the same length."
     assert np.isclose(sum(split_vals), 1), "split_vals must sum to one."
 

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -114,14 +114,14 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
 
     print('Saving packaged file to {}'.format(op.join(dest_folder, 'data.npz')))
 
-    if len(split_vals == 2):
+    if len(split_vals) == 2:
         np.savez(op.join(dest_folder, 'data.npz'),
                  x_train=x_vals_split_lst[0],
                  y_train=y_vals_split_lst[0],
                  x_test=x_vals_split_lst[1],
                  y_test=y_vals_split_lst[1])
 
-    if len(split_vals == 3):
+    if len(split_vals) == 3:
         np.savez(op.join(dest_folder, 'data.npz'),
                  x_train=x_vals_split_lst[0],
                  y_train=y_vals_split_lst[1],

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -35,7 +35,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
         Percentage of data to put in each catagory listed in split_names.
         Must be floats and must sum to one.
     split_names: list
-        Default: ['train', 'test'] 
+        Default: ['train', 'test']
         List of names for each subset of the data.
     **kwargs: dict
         Other properties from CLI config passed as keywords to other utility functions
@@ -44,9 +44,10 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
     if seed:
         np.random.seed(seed)
 
-    #assert len(split_names) == 2 or len(split_names) == 3.
-    assert len(split_names) == len(split_vals), "split_names and split_vals must be the same length."
-    assert np.isclose(sum(split_vals), 1), "split_vals must sum to one."
+    if len(split_names) != len(split_vals):
+        raise ValueError('`split_names` and `split_vals` must be the same length. Please update your config.')
+    if not np.isclose(sum(split_vals), 1):
+        raise ValueError('`split_vals` must sum to one. Please update your config.')
 
     # open labels file, create tile array
     labels_file = op.join(dest_folder, 'labels.npz')

--- a/label_maker/package.py
+++ b/label_maker/package.py
@@ -46,7 +46,7 @@ def package_directory(dest_folder, classes, imagery, ml_type, seed=False, split_
 
     assert len(split_names) == 2 or len(split_names) == 3.
     assert len(split_names) == len(split_vals), "split_names and split_vals must be the same length."
-    assert sum(split_vals) == 1, "split_vals must sum to one."
+    assert np.isclose(sum(split_vals), 1), "split_vals must sum to one."
 
     # open labels file, create tile array
     labels_file = op.join(dest_folder, 'labels.npz')

--- a/label_maker/validate.py
+++ b/label_maker/validate.py
@@ -30,5 +30,7 @@ schema = {
     'background_ratio': {'type': 'float'},
     'ml_type': {'allowed': ['classification', 'object-detection', 'segmentation'], 'required': True},
     'seed': {'type': 'integer'},
-    'imagery_offset': {'type': 'list', 'schema': {'type': 'integer'}, 'minlength': 2, 'maxlength': 2}
+    'imagery_offset': {'type': 'list', 'schema': {'type': 'integer'}, 'minlength': 2, 'maxlength': 2},
+    'split_vals': {'type': 'list', 'schema': {'type': 'float'}, 'minlength': 2, 'maxlength': 3},
+    'split_names': {'type': 'list', 'schema': {'type': 'string'}, 'minlength': 2, 'maxlength': 3}
 }

--- a/label_maker/validate.py
+++ b/label_maker/validate.py
@@ -31,6 +31,6 @@ schema = {
     'ml_type': {'allowed': ['classification', 'object-detection', 'segmentation'], 'required': True},
     'seed': {'type': 'integer'},
     'imagery_offset': {'type': 'list', 'schema': {'type': 'integer'}, 'minlength': 2, 'maxlength': 2},
-    'split_vals': {'type': 'list', 'schema': {'type': 'float'}, 'minlength': 2, 'maxlength': 3},
-    'split_names': {'type': 'list', 'schema': {'type': 'string'}, 'minlength': 2, 'maxlength': 3}
+    'split_vals': {'type': 'list', 'schema': {'type': 'float'}},
+    'split_names': {'type': 'list', 'schema': {'type': 'string'}}
 }

--- a/test/fixtures/integration/config_3way.integration.json
+++ b/test/fixtures/integration/config_3way.integration.json
@@ -19,5 +19,5 @@
   "ml_type": "classification",
   "seed": 19,
   "split_names": ["train", "test", "val"],
-  "split_vals": [0.6, 0.2, 0.2]
+  "split_vals": [0.7, 0.2, 0.1]
 }

--- a/test/fixtures/integration/config_3way.integration.json
+++ b/test/fixtures/integration/config_3way.integration.json
@@ -1,0 +1,23 @@
+{"country": "portugal",
+  "bounding_box": [
+    -9.4575,
+    38.8467,
+    -9.4510,
+    38.8513
+  ],
+  "zoom": 17,
+  "classes": [
+    { "name": "Water Tower", "filter": ["==", "man_made", "water_tower"] },
+    { "name": "Building", "filter": ["has", "building"] },
+    { "name": "Farmland", "filter": ["==", "landuse", "farmland"] },
+    { "name": "Ruins", "filter": ["==", "historic", "ruins"] },
+    { "name": "Parking", "filter": ["==", "amenity", "parking"] },
+    { "name": "Roads", "filter": ["has", "highway"] }
+  ],
+  "imagery": "https://api.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token=ACCESS_TOKEN",
+  "background_ratio": 1,
+  "ml_type": "classification",
+  "seed": 19,
+  "split_names": ["train", "test", "val"],
+  "split_vals": [0.7, 0.2, 0.1]
+}

--- a/test/fixtures/integration/config_3way.integration.json
+++ b/test/fixtures/integration/config_3way.integration.json
@@ -19,5 +19,5 @@
   "ml_type": "classification",
   "seed": 19,
   "split_names": ["train", "test", "val"],
-  "split_vals": [0.7, 0.2, 0.1]
+  "split_vals": [0.6, 0.2, 0.2]
 }

--- a/test/integration/test_classification_package.py
+++ b/test/integration/test_classification_package.py
@@ -11,18 +11,12 @@ class TestClassificationPackage(unittest.TestCase):
     """Tests for classification package creation"""
     @classmethod
     def setUpClass(cls):
-        try:
-            makedirs('integration-cl')
-        except FileExistsError:
-            pass
+
+        makedirs('integration-cl')
         copyfile('test/fixtures/integration/labels-cl.npz', 'integration-cl/labels.npz')
         copytree('test/fixtures/integration/tiles', 'integration-cl/tiles')
 
-        try:
-            makedirs('integration-cl-split')
-
-        except FileExistsError:
-            pass
+        makedirs('integration-cl-split')
         copyfile('test/fixtures/integration/labels-cl.npz', 'integration-cl-split/labels.npz')
         copytree('test/fixtures/integration/tiles', 'integration-cl-split/tiles')
 

--- a/test/integration/test_classification_package.py
+++ b/test/integration/test_classification_package.py
@@ -59,8 +59,7 @@ class TestClassificationPackage(unittest.TestCase):
     def test_cli_3way_split(self):
         """Verify data.npz produced by CLI when split into train/test/val"""
 
-        cmd = 'label-maker package --dest integration-cl-split --config ' \
-              'test/fixtures/integration/config_3way.integration.json '
+        cmd = 'label-maker package --dest integration-cl-split --config test/fixtures/integration/config_3way.integration.json'
         cmd = cmd.split(' ')
         subprocess.run(cmd, universal_newlines=True)
 

--- a/test/integration/test_classification_package.py
+++ b/test/integration/test_classification_package.py
@@ -73,5 +73,3 @@ class TestClassificationPackage(unittest.TestCase):
         self.assertEqual(data['y_train'].shape, (5, 7))
         self.assertEqual(data['y_test'].shape, (2, 7))
         self.assertEqual(data['y_val'].shape, (1, 7))
-
-

--- a/test/integration/test_classification_package.py
+++ b/test/integration/test_classification_package.py
@@ -7,11 +7,12 @@ import subprocess
 
 import numpy as np
 
+
 class TestClassificationPackage(unittest.TestCase):
     """Tests for classification package creation"""
+
     @classmethod
     def setUpClass(cls):
-
         makedirs('integration-cl')
         copyfile('test/fixtures/integration/labels-cl.npz', 'integration-cl/labels.npz')
         copytree('test/fixtures/integration/tiles', 'integration-cl/tiles')
@@ -58,7 +59,8 @@ class TestClassificationPackage(unittest.TestCase):
     def test_cli_3way_split(self):
         """Verify data.npz produced by CLI when split into train/test/val"""
 
-        cmd = 'label-maker package --dest integration-cl-split --config test/fixtures/integration/config_3way.integration.json'
+        cmd = 'label-maker package --dest integration-cl-split --config ' \
+              'test/fixtures/integration/config_3way.integration.json '
         cmd = cmd.split(' ')
         subprocess.run(cmd, universal_newlines=True)
 

--- a/test/integration/test_classification_package.py
+++ b/test/integration/test_classification_package.py
@@ -11,13 +11,25 @@ class TestClassificationPackage(unittest.TestCase):
     """Tests for classification package creation"""
     @classmethod
     def setUpClass(cls):
-        makedirs('integration-cl')
+        try:
+            makedirs('integration-cl')
+        except FileExistsError:
+            pass
         copyfile('test/fixtures/integration/labels-cl.npz', 'integration-cl/labels.npz')
         copytree('test/fixtures/integration/tiles', 'integration-cl/tiles')
+
+        try:
+            makedirs('integration-cl-split')
+
+        except FileExistsError:
+            pass
+        copyfile('test/fixtures/integration/labels-cl.npz', 'integration-cl-split/labels.npz')
+        copytree('test/fixtures/integration/tiles', 'integration-cl-split/tiles')
 
     @classmethod
     def tearDownClass(cls):
         rmtree('integration-cl')
+        rmtree('integration-cl-split')
 
     def test_cli(self):
         """Verify data.npz produced by CLI"""
@@ -48,3 +60,24 @@ class TestClassificationPackage(unittest.TestCase):
              [0, 0, 0, 0, 0, 0, 1]]
         )
         self.assertTrue(np.array_equal(data['y_test'], expected_y_test))
+
+    def test_cli_3way_split(self):
+        """Verify data.npz produced by CLI when split into train/test/val"""
+
+        cmd = 'label-maker package --dest integration-cl-split --config test/fixtures/integration/config_3way.integration.json'
+        cmd = cmd.split(' ')
+        subprocess.run(cmd, universal_newlines=True)
+
+        data = np.load('integration-cl-split/data.npz')
+
+        # validate our image data with shapes
+        self.assertEqual(data['x_train'].shape, (5, 256, 256, 3))
+        self.assertEqual(data['x_test'].shape, (2, 256, 256, 3))
+        self.assertEqual(data['x_val'].shape, (1, 256, 256, 3))
+
+        # validate label data with shapes
+        self.assertEqual(data['y_train'].shape, (5, 7))
+        self.assertEqual(data['y_test'].shape, (2, 7))
+        self.assertEqual(data['y_val'].shape, (1, 7))
+
+


### PR DESCRIPTION
The PR to address the enhancement outlined in [issue 147](https://github.com/developmentseed/label-maker/issues/147) introduces the option to split data into added `train/test/validate` of user specified sizes, this code still keeps the previous label-maker default of` .8/.2 ` `train/test` split. 

cc @wronk , @drewbo 