### PR TITLE
Update argument list of download_tile_tms

### DIFF
--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -70,7 +70,7 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
 
     # get image acquisition function based on imagery string
     image_function = get_image_function(imagery)
-    kwargs['imagery_offset'] = imagery_offset 
+    kwargs['imagery_offset'] = imagery_offset
 
     for tile in tiles:
         image_function(tile, imagery, tiles_dir, kwargs)

--- a/label_maker/utils.py
+++ b/label_maker/utils.py
@@ -24,7 +24,7 @@ def class_match(ml_type, label, i):
         return np.count_nonzero(label == i)
     return None
 
-def download_tile_tms(tile, imagery, folder, kwargs):
+def download_tile_tms(tile, imagery, folder,imagery_offset, kwargs):
     """Download a satellite image tile from a tms endpoint"""
     o = urlparse(imagery)
     _, image_format = op.splitext(o.path)


### PR DESCRIPTION
As get_image_function in utils.py returns either of get_tile_tif or get_tile_wms or download_tile_tms. All three functions should have the same argument signature. 

Fixes issue https://github.com/developmentseed/label-maker/issues/156