### PR TITLE
speed up tile download with concurrent processing

### DIFF
--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -76,9 +76,6 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, th
     image_function = get_image_function(imagery)
     kwargs['imagery_offset'] = imagery_offset
 
-    t = time.perf_counter()
     with concurrent.futures.ThreadPoolExecutor(max_workers=threadcount) as executor:
-        {executor.submit(image_function, tile, imagery, tiles_dir, kwargs): tile for tile in tiles}
+        [executor.submit(image_function, tile, imagery, tiles_dir, kwargs) for tile in tiles]
         executor.shutdown(wait=True)
-    elapsed_time = time.perf_counter() - t
-    print(elapsed_time)

--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -4,7 +4,6 @@
 import concurrent.futures
 from os import makedirs, path as op
 from random import shuffle
-import time
 
 import numpy as np
 

--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from label_maker.utils import get_image_function
 
-def download_images(dest_folder, classes, imagery, ml_type, background_ratio, imagery_offset=False, **kwargs):
+def download_images(dest_folder, classes, imagery, ml_type, background_ratio, threadcount, imagery_offset=False, **kwargs):
     """Download satellite images specified by a URL and a label.npz file
     Parameters
     ------------
@@ -30,6 +30,8 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
     background_ratio: float
         Determines the number of background images to download in single class problems. Ex. A value
         of 1 will download an equal number of background images to class images.
+    threadcount: int
+        Number of threads to use for faster parallel image download
     imagery_offset: list
         An optional list of integers representing the number of pixels to offset imagery. Ex. [15, -5] will
         move the images 15 pixels right and 5 pixels up relative to the requested tile bounds
@@ -74,6 +76,9 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
     image_function = get_image_function(imagery)
     kwargs['imagery_offset'] = imagery_offset
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=50) as executor:
-        future_to_tile = {executor.submit(image_function, tile, imagery, tiles_dir, kwargs): tile for tile in tiles}
+    t = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=threadcount) as executor:
+        {executor.submit(image_function, tile, imagery, tiles_dir, kwargs): tile for tile in tiles}
         executor.shutdown(wait=True)
+    elapsed_time = time.perf_counter() - t
+    print(elapsed_time)

--- a/label_maker/images.py
+++ b/label_maker/images.py
@@ -4,6 +4,7 @@
 import concurrent.futures
 from os import makedirs, path as op
 from random import shuffle
+import time
 
 import numpy as np
 
@@ -73,12 +74,6 @@ def download_images(dest_folder, classes, imagery, ml_type, background_ratio, im
     image_function = get_image_function(imagery)
     kwargs['imagery_offset'] = imagery_offset
 
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=50) as executor:
         future_to_tile = {executor.submit(image_function, tile, imagery, tiles_dir, kwargs): tile for tile in tiles}
-        for future in concurrent.futures.as_completed(future_to_tile):
-            tile = future_to_tile[future]
-            try:
-                data=future.result()
-            except Exception as exc:
-                print('%r generated as exception: %s' % (tile, exc))
+        executor.shutdown(wait=True)

--- a/label_maker/main.py
+++ b/label_maker/main.py
@@ -50,7 +50,7 @@ def parse_args(args):
     subparsers.add_parser('download', parents=[pparser], help='', formatter_class=dhf)
     l = subparsers.add_parser('labels', parents=[pparser], help='', formatter_class=dhf)
     p = subparsers.add_parser('preview', parents=[pparser], help='', formatter_class=dhf)
-    subparsers.add_parser('images', parents=[pparser], help='', formatter_class=dhf)
+    i = subparsers.add_parser('images', parents=[pparser], help='', formatter_class=dhf)
     subparsers.add_parser('package', parents=[pparser], help='', formatter_class=dhf)
 
     # labels has an optional parameter
@@ -59,6 +59,10 @@ def parse_args(args):
     # preview has an optional parameter
     p.add_argument('-n', '--number', default=5, type=int,
                    help='number of examples images to create per class')
+
+    #images has optional parameter
+    i.add_argument('-t', '--threadcount', default=50, type=int,
+                    help= 'thread count to use')
 
     # turn namespace into dictinary
     parsed_args = vars(parser.parse_args(args))
@@ -109,7 +113,8 @@ def cli():
         number = args.get('number')
         preview(dest_folder=dest_folder, number=number, **config)
     elif cmd == 'images':
-        download_images(dest_folder=dest_folder, **config)
+        threadcount = args.get('threadcount')
+        download_images(dest_folder=dest_folder, threadcount=threadcount, **config)
     elif cmd == 'package':
         package_directory(dest_folder=dest_folder, **config)
 

--- a/label_maker/main.py
+++ b/label_maker/main.py
@@ -61,7 +61,7 @@ def parse_args(args):
                    help='number of examples images to create per class')
 
     #images has optional parameter
-    i.add_argument('-t', '--threadcount', default=50, type=int,
+    i.add_argument('-t', '--threadcount', default=10, type=int,
                     help= 'thread count to use')
 
     # turn namespace into dictinary


### PR DESCRIPTION
to address issue #12 

- uses ThreadPoolExecutor to speed up tile downloads 
- previously downloading ~400 tiles from a mapbox endpoint took ~31 second, with using the threadpool executor downloading ~400 tiles takes ~8 seconds! 
- if this change aligns with what you were thinking, I think it's possible to do something similar with the [child tile download](https://github.com/developmentseed/label-maker/blob/tile_download/label_maker/utils.py#L74-L88) for the supertiles special case, and I can investigate

cc @drewbo 